### PR TITLE
Fix custom provider interface compatibility

### DIFF
--- a/services/llm/customProvider.ts
+++ b/services/llm/customProvider.ts
@@ -107,7 +107,10 @@ export class CustomProvider implements LlmProvider {
   
   async findBestMatchBatch(
     shoryRecords: { id: string; make: string; model: string; }[],
+    icMakeModelList: { make: string; model: string; code?: string }[],
   ): Promise<Map<string, WebSearchBatchResult>> {
+    // Parameter currently unused but required for interface compatibility
+    void icMakeModelList;
     console.warn("findBestMatchBatch (Web Search) is not supported by the CustomProvider and was called.");
     const results = new Map<string, WebSearchBatchResult>();
     shoryRecords.forEach(rec => {


### PR DESCRIPTION
## Summary
- update `findBestMatchBatch` in CustomProvider to accept `icMakeModelList` parameter
- keep return type Map<string, WebSearchBatchResult>

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68764f0eabdc833398f07ee79f4b38cc